### PR TITLE
build(dependencies): 修复分页显示

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,9 +64,13 @@
         <dependency>
             <groupId>com.baomidou</groupId>
             <artifactId>mybatis-plus-spring-boot3-starter</artifactId>
-            <version>3.5.10.1</version>
+            <version>3.5.11</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>mybatis-plus-jsqlparser</artifactId>
+            <version>3.5.11</version>
+        </dependency>
         <!-- JJWT 依赖 -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/src/main/java/com/example/goodlearnai/v1/config/MybatisPlusConfig.java
+++ b/src/main/java/com/example/goodlearnai/v1/config/MybatisPlusConfig.java
@@ -1,0 +1,20 @@
+package com.example.goodlearnai.v1.config;
+
+import com.baomidou.mybatisplus.annotation.DbType;
+import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
+import com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Mouse
+ */
+@Configuration
+public class MybatisPlusConfig {
+    @Bean
+    public MybatisPlusInterceptor mybatisPlusInterceptor() {
+        MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
+        interceptor.addInnerInterceptor(new PaginationInnerInterceptor(DbType.MYSQL));
+        return interceptor;
+    }
+}


### PR DESCRIPTION
- 将 mybatis-plus-spring-boot3-starter版本从 3.5.10.1 升级到 3.5.11- 添加 mybatis-plus-jsqlparser 依赖，版本为 3.5.11
- 新增 MybatisPlusConfig 配置类，用于配置 MyBatis-Plus 拦截器